### PR TITLE
fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Go implementation of SDP (Session Description Protocol)
 ## Installation
 
 ```sh
-go get github.com/pixelbender/go-sdp
+go get github.com/pixelbender/go-sdp/sdp
 ```
 
 ## SDP Decoding


### PR DESCRIPTION
This pr fixes the installation command listed in the readme. The previous version generated the following error:

```
$ go get github.com/pixelbender/go-sdp

package github.com/pixelbender/go-sdp: no buildable Go source files in /GOPATH/src/github.com/pixelbender/go-sdp
```