### PR TITLE
Some corner cases fixed

### DIFF
--- a/sdp/decoder.go
+++ b/sdp/decoder.go
@@ -172,7 +172,7 @@ func (d *Decoder) media(m *Media, f byte, v string) error {
 func (d *Decoder) format(m *Media, a *Attr) error {
 	p, ok := d.fields(a.Value, 2)
 	if !ok {
-		return errFormat
+		return nil
 	}
 	var (
 		pt     = p[0]
@@ -283,7 +283,7 @@ func (d *Decoder) connection(v string) (*Connection, error) {
 	}
 	c := new(Connection)
 	c.Network, c.Type, c.Address = p[0], p[1], p[2]
-	p, ok = d.split(c.Address, '/', 3)
+	p, _ = d.split(c.Address, '/', 3)
 	switch c.Type {
 	case TypeIPv4:
 		if len(p) > 2 {
@@ -299,7 +299,6 @@ func (d *Decoder) connection(v string) (*Connection, error) {
 				return nil, err
 			}
 			c.Address, c.TTL = p[0], int(ttl)
-			p = append(p[:1], p[2:]...)
 		}
 	case TypeIPv6:
 		if len(p) > 1 {

--- a/sdp/encoder.go
+++ b/sdp/encoder.go
@@ -147,8 +147,12 @@ func (w writer) media(m *Media) writer {
 	if f := m.FormatDescr; f != "" {
 		w = w.sp().str(f)
 	} else {
-		for _, it := range m.Format {
-			w = w.sp().int(int64(it.Payload))
+		if len(m.Format) > 0 {
+			for _, it := range m.Format {
+				w = w.sp().int(int64(it.Payload))
+			}
+		} else if m.PortNum == 0 {
+			w = w.sp().str("0")
 		}
 	}
 	if m.Information != "" {


### PR DESCRIPTION
Fixed 2 corner cases:
1. Attributes without parameters now don't cause parsing error
Example:
'a=fmtp:104'
2. Decoder now adds '0' format to the removed media (port == 0) without specified formats:
Example:
'm=video 0 RTP/AVP 0'