### PR TITLE
add empty PT list support

### DIFF
--- a/sdp/decoder.go
+++ b/sdp/decoder.go
@@ -232,11 +232,17 @@ func (d *Decoder) rtpmap(f *Format, v string) error {
 }
 
 func (d *Decoder) proto(m *Media, v string) error {
+	var formats string
 	p, ok := d.fields(v, 4)
-	if !ok {
-		return errFormat
+	if ok {
+		formats = p[3]
+	} else {
+		p, ok = d.fields(v, 3)
+		if !ok {
+			return errFormat
+		}
 	}
-	formats := p[3]
+
 	m.Type, m.Proto = p[0], p[2]
 	p, ok = d.split(p[1], '/', 2)
 	var err error
@@ -252,6 +258,10 @@ func (d *Decoder) proto(m *Media, v string) error {
 		m.FormatDescr = formats
 		return nil
 	}
+	if len(formats) == 0 {
+		return nil
+	}
+
 	p, _ = d.fields(formats, maxLineSize)
 	for _, it := range p {
 		pt, err := strconv.Atoi(it)

--- a/sdp/encoder.go
+++ b/sdp/encoder.go
@@ -147,12 +147,8 @@ func (w writer) media(m *Media) writer {
 	if f := m.FormatDescr; f != "" {
 		w = w.sp().str(f)
 	} else {
-		if len(m.Format) > 0 {
-			for _, it := range m.Format {
-				w = w.sp().int(int64(it.Payload))
-			}
-		} else if m.PortNum == 0 {
-			w = w.sp().str("0")
+		for _, it := range m.Format {
+			w = w.sp().int(int64(it.Payload))
 		}
 	}
 	if m.Information != "" {

--- a/sdp/sdp_test.go
+++ b/sdp/sdp_test.go
@@ -102,6 +102,34 @@ a=fmtp:100 profile-level-id=42c01f;level-asymmetry-allowed=1
 		},
 	},
 	{
+		Name: "No PT example",
+		Data: `v=0
+o=alice 2890844526 2890844526 IN IP4 alice.example.org
+s=Example
+t=0 0
+m=audio 49170 RTP/AVP
+`,
+		Session: &Session{
+			Origin: &Origin{
+				Username:       "alice",
+				SessionID:      2890844526,
+				SessionVersion: 2890844526,
+				Network:        NetworkInternet,
+				Type:           TypeIPv4,
+				Address:        "alice.example.org",
+			},
+			Name: "Example",
+			Media: []*Media{
+				{
+					Type:   "audio",
+					Port:   49170,
+					Proto:  "RTP/AVP",
+					Format: []*Format{},
+				},
+			},
+		},
+	},
+	{
 		Name: "Readme Example",
 		Data: `v=0
 o=alice 2890844526 2890844526 IN IP4 alice.example.org


### PR DESCRIPTION
RFC 4566, p 5.14, page 23: 

...
If the <proto> sub-field is "RTP/AVP" or "RTP/SAVP" the <fmt> sub-fields contain RTP payload type numbers.  **WHEN** a list of payload type numbers is given, this implies that all of these payload formats MAY be used in the session
...